### PR TITLE
Added cron tasks for system monitoring and sites monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,3 +70,5 @@ gem 'turbolinks', '~> 5.0.0'
 gem 'webpacker', '~> 3.0.2'
 # Monitoring
 gem 'net-ping', '~> 2.0.2'
+# Cron tasks
+gem 'whenever', '~> 0.10.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
       xpath (~> 2.0)
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
+    chronic (0.10.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.0.5)
@@ -244,6 +245,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    whenever (0.10.0)
+      chronic (>= 0.6.3)
     xpath (2.1.0)
       nokogiri (~> 1.3)
 
@@ -279,6 +282,7 @@ DEPENDENCIES
   turbolinks (~> 5.0.0)
   tzinfo-data
   webpacker (~> 3.0.2)
+  whenever (~> 0.10.0)
 
 BUNDLED WITH
    1.16.0

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ module BProjectEther
     config.autoload_paths += %W[#{config.root}/lib/monitoring]
 
     config.paths.add File.join('app', 'api'), glob: File.join('**', '*.rb')
-	config.autoload_paths += Dir[Rails.root.join('app', 'api', '*')]
+    config.autoload_paths += Dir[Rails.root.join('app', 'api', '*')]
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,10 +1,10 @@
 # whenever cron jobs
-set :output, {error: 'log/cron_error.log', standard: 'log/cron.log'}
+set :output, {error: 'log/cron_errors.log', standard: 'log/cron.log'}
 set :environment, 'development'
 env :PATH, ENV['PATH']
 
 # Monitor harware system every 15 minutes
-every 1.minutes do
+every 15.minutes do
   rake 'monitor:system'
 end
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,14 @@
+# whenever cron jobs
+set :output, {error: 'log/cron_error.log', standard: 'log/cron.log'}
+set :environment, 'development'
+env :PATH, ENV['PATH']
+
+# Monitor harware system every 15 minutes
+every 1.minutes do
+  rake 'monitor:system'
+end
+
+# Monitor Scraping sites status every hour
+every :hour do
+  rake 'monitor:connection'
+end

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -1,0 +1,13 @@
+namespace :cron do
+  desc 'Task to load cron tasks with whenever gem'
+  task load: [:environment, :dotenv] do
+    system 'whenever --update-crontab'
+    puts 'Crontab updated'
+  end
+
+  desc 'Task to remove cron tasks with whenever gem'
+  task remove: [:environment, :dotenv] do
+    system 'whenever -c'
+    puts 'Crontab removed'
+  end
+end

--- a/lib/tasks/monitor.rake
+++ b/lib/tasks/monitor.rake
@@ -3,7 +3,7 @@ require 'monitoring/connection'
 
 namespace :monitor do
   desc 'Prints all System information (Server Monitoring)'
-  task usage: [:environment, :dotenv] do
+  task system: [:environment, :dotenv] do
     disk_used = Usagewatch::Linux.uw_diskused
     disk_used_perc = Usagewatch::Linux.uw_diskused_perc
     cpu_used = Usagewatch::Linux.uw_cpuused
@@ -20,15 +20,18 @@ namespace :monitor do
                           bandwidth_rx: bandrx, 
                           bandwidth_tx: bandtx, 
                           disk_reads: diskioreads, 
-                          disk_writes: diskiowrites)                          
+                          disk_writes: diskiowrites)
+    puts "System Log executed sucessfully at #{Time.now}"
   end
 
-  task test_connection: [:environment, :dotenv] do
+  task connection: [:environment, :dotenv] do
     net_status = Monitoring::Connection.test
     if net_status
-      store = Store.find_by(name: 'Zmart')
-      result = store.check_page
+      stores = Store.all
+      stores.each do |s|
+        result = s.check_page
+        puts 'Site: ' + s.name + ' is down!' unless result
+      end
     end
-    puts result
   end
 end


### PR DESCRIPTION
# Cron tasks for monitoring module

## Dependences
First, all gems must be installed, you can use bundler for that.
```
bundle install
```

Also, is needed to install whenever in your OS
```
$ sudo apt-get install ruby-whenever
```
## Usage
There are rake tasks to create the crontab, just use
* To create crontab
```
rake cron:load
```

* To remove crontab (stop cron jobs)
```
rake cron:remove
```
## Logs
All logs are stored in the SQLDB tables 'server_status_logs' for system logs, and 'store_logs' for Store sites status logs.

Cron logs are stored in file 'logs/cron.log' and cron errors in file 'logs/cron_errors.log'.

## Time intervals
* System monitoring is set to log every 15 minutes.
* Stores sites status monitoring is set to log every 1 hour.